### PR TITLE
feat: agregar 16 razones financieras, antiguedad y ultima factura 69-B

### DIFF
--- a/Fluxo_IA_visual/models/responses_precalificacion.py
+++ b/Fluxo_IA_visual/models/responses_precalificacion.py
@@ -123,6 +123,7 @@ class PrequalificationResponse(BaseModel):
         name: str
         percentage: float
         start_date: Optional[str] = None # "YYYY-MM-DD"
+        seniority_years: Optional[int] = 0 # Años desde el inicio de esta actividad económica
     
     class Stats(BaseModel):
         mean: float
@@ -167,6 +168,8 @@ class PrequalificationResponse(BaseModel):
         issued_amount: float = 0.0
         received_count: int = 0
         received_amount: float = 0.0
+
+        last_invoice_date: str = "N/A"
 
     class AdvancedPeriodMetrics(BaseModel):
         """
@@ -237,7 +240,6 @@ class PrequalificationResponse(BaseModel):
         gross_profit: float = 0.0 # Utilidad Bruta
         gross_loss: float = 0.0   # Pérdida Bruta
         
-        # Dual fields (Syntage separa Profit de Loss)
         net_profit: float = 0.0
         net_loss: float = 0.0
         
@@ -246,32 +248,73 @@ class PrequalificationResponse(BaseModel):
         
         ebt_profit: float = 0.0
         ebt_loss: float = 0.0
+        
+        # CAMPOS CRUDOS PARA RAZONES FINANCIERAS
+        current_assets: float = 0.0        # Activo circulante / a corto plazo
+        current_liabilities: float = 0.0   # Pasivo circulante / a corto plazo
+        cash_and_equivalents: float = 0.0  # Efectivo y equivalentes
+        inventory: float = 0.0             # Inventarios
+        accounts_receivable: float = 0.0   # Cuentas por cobrar
+        accounts_payable: float = 0.0      # Cuentas por pagar
+        fixed_assets: float = 0.0          # Activo fijo (Propiedades, planta y eq)
+        retained_earnings: float = 0.0     # Utilidades retenidas / acumuladas
+        cogs: float = 0.0                  # Costo de ventas
+        interest_expense: float = 0.0      # Gastos financieros / Intereses
+        operating_cash_flow: float = 0.0   # Flujo operativo de caja (si viene en el árbol)
 
     class FinancialRatioYear(BaseModel): # --- OUTPUT DE CALCULADORA ---
         year: str
-        roa: float
-        roe: float
-        net_profit_margin_percent: float # Margen neto de utilidad (%)
-        ebit: float
-        ebt: float
-        nopat: float
-
-        # -- Datos Consolidados --
+        
+        # Datos Consolidados
         input_assets: float
-        input_liabilities: float     # Pasivo
+        input_liabilities: float
         input_equity: float
         input_revenue: float
-        input_gross_profit: float    # Bruta consolidada (Profit - Loss)
+        input_gross_profit: float
         input_net_income: float
         input_taxes: float
-
         input_assets_short_term: float = 0.0
         input_assets_long_term: float = 0.0
         input_liabilities_short_term: float = 0.0
         input_liabilities_long_term: float = 0.0
         input_equity_social: float = 0.0
         
-        # --- Datos Crudos  ---
+        # RATIOS CALCULADOS
+        # ROI
+        roa: float
+        roe: float
+        net_profit_margin_percent: float
+        roa_tax_strategy: float = 0.0  # Rendimiento activos con estrategia fiscal
+        
+        # Liquidez
+        current_ratio: float = 0.0     # Razón actual / circulante
+        quick_ratio: float = 0.0       # Prueba del ácido
+        cash_ratio: float = 0.0        # Liquidez inmediata
+        
+        # Estructura de Capital y Solvencia
+        leverage: float = 0.0          # Apalancamiento
+        debt_ratio: float = 0.0        # Endeudamiento
+        interest_coverage: float = 0.0 # Cobertura de intereses
+        
+        # Flujo de Fondos
+        operating_cash_flow: float = 0.0
+        cash_flow_coverage: float = 0.0
+        working_capital: float = 0.0   # Capital de trabajo
+        
+        # Desempeño Operativo
+        dio: float = 0.0               # Días de inventario
+        dso: float = 0.0               # Días CxC
+        dpo: float = 0.0               # Días CxP
+        fixed_asset_turnover: float = 0.0 # Rotación activo fijo
+        total_asset_turnover: float = 0.0 # Rotación activo total
+        altman_z_score: float = 0.0       # Indicador de Altman
+
+        # Variables base
+        ebit: float
+        ebt: float
+        nopat: float
+        
+        # Datos crudos auditoría
         raw_net_profit: float = 0.0
         raw_net_loss: float = 0.0
         raw_ebit_profit: float = 0.0

--- a/Fluxo_IA_visual/services/prequalification/calculator_service.py
+++ b/Fluxo_IA_visual/services/prequalification/calculator_service.py
@@ -18,7 +18,7 @@ class FinancialCalculatorService:
         year = inputs.year
         logger.debug(f"--- Calculando Ratios para el Año {year} ---")
 
-        # 1. RESOLUCIÓN DE SIGNOS (Profit vs Loss)
+        # 1. RESOLUCIÓN DE SIGNOS
         gross_income = self._resolve_sign(inputs.gross_profit, inputs.gross_loss, "Gross Profit")
         net_income = self._resolve_sign(inputs.net_profit, inputs.net_loss, "Net Income")
         ebit = self._resolve_sign(inputs.ebit_profit, inputs.ebit_loss, "EBIT")
@@ -36,37 +36,89 @@ class FinancialCalculatorService:
             ebt = net_income + inputs.taxes
 
         # 3. CÁLCULO DE RAZONES
+        # Aseguramos que COGS e Intereses sean absolutos para no alterar el sentido de las fórmulas
+        cogs_abs = abs(inputs.cogs)
+        interest_exp_abs = abs(inputs.interest_expense)
+
+        # A) Liquidez
+        current_ratio = self._safe_division(inputs.current_assets, inputs.current_liabilities)
+        quick_ratio = self._safe_division(inputs.current_assets - inputs.inventory, inputs.current_liabilities)
+        cash_ratio = self._safe_division(inputs.cash_and_equivalents, inputs.current_liabilities)
+
+        # B) Rendimiento sobre la Inversión (ROI)
         roa = self._safe_division(net_income, inputs.assets)
         roe = self._safe_division(net_income, inputs.equity)
         margin_percent = self._safe_division(net_income, inputs.revenue) * 100
+        # Formula Genérica: EBT / Activos. (Se cambiará después)
+        roa_tax_strategy = self._safe_division(ebt, inputs.assets) 
 
-        # Logs finales de los valores calculados
-        logger.debug(
-            f"RESULTADOS {year}: "
-            f"NetIncome={net_income:.2f} | EBIT={ebit:.2f} | NOPAT={nopat:.2f} | "
-            f"ROA={roa:.4f} | ROE={roe:.4f} | Margin={margin_percent:.2f}%"
-        )
+        # C) Estructura de Capital y Solvencia
+        leverage = self._safe_division(inputs.liabilities, inputs.equity)
+        debt_ratio = self._safe_division(inputs.liabilities, inputs.assets)
+        interest_coverage = self._safe_division(ebit, interest_exp_abs)
+
+        # D) Flujo de Fondos
+        ocf = inputs.operating_cash_flow
+        cash_flow_coverage = self._safe_division(ocf, inputs.liabilities)
+        working_capital = inputs.current_assets - inputs.current_liabilities
+
+        # E) Desempeño Operativo
+        dio = self._safe_division(inputs.inventory, cogs_abs) * 365
+        dso = self._safe_division(inputs.accounts_receivable, inputs.revenue) * 365
+        dpo = self._safe_division(inputs.accounts_payable, cogs_abs) * 365
+        fixed_asset_turnover = self._safe_division(inputs.revenue, inputs.fixed_assets)
+        total_asset_turnover = self._safe_division(inputs.revenue, inputs.assets)
+
+        # F) Indicador de Altman (Z-Score para empresas privadas)
+        t1 = self._safe_division(working_capital, inputs.assets)
+        t2 = self._safe_division(inputs.retained_earnings, inputs.assets)
+        t3 = self._safe_division(ebit, inputs.assets)
+        t4 = self._safe_division(inputs.equity, inputs.liabilities)
+        t5 = self._safe_division(inputs.revenue, inputs.assets)
+        altman_z = (1.2 * t1) + (1.4 * t2) + (3.3 * t3) + (0.6 * t4) + (1.0 * t5)
 
         return PrequalificationResponse.FinancialRatioYear(
-            # Ratios Calculados
             year=year,
+            
+            # --- Ratios Originales y ROI ---
             roa=round(roa, 4),
             roe=round(roe, 4),
             net_profit_margin_percent=round(margin_percent, 2),
+            roa_tax_strategy=round(roa_tax_strategy, 4),
+            
+            # --- Ratios Nuevos ---
+            current_ratio=round(current_ratio, 2),
+            quick_ratio=round(quick_ratio, 2),
+            cash_ratio=round(cash_ratio, 2),
+            
+            leverage=round(leverage, 2),
+            debt_ratio=round(debt_ratio, 4),
+            interest_coverage=round(interest_coverage, 2),
+            
+            operating_cash_flow=round(ocf, 2),
+            cash_flow_coverage=round(cash_flow_coverage, 2),
+            working_capital=round(working_capital, 2),
+            
+            dio=round(dio, 1),
+            dso=round(dso, 1),
+            dpo=round(dpo, 1),
+            fixed_asset_turnover=round(fixed_asset_turnover, 2),
+            total_asset_turnover=round(total_asset_turnover, 2),
+            altman_z_score=round(altman_z, 2),
+
+            # --- Base e Inputs crudos ---
             ebit=round(ebit, 2),
             ebt=round(ebt, 2),
             nopat=round(nopat, 2),
 
-            # Datos Consolidados (Evidencia)
             input_assets=round(inputs.assets, 2),
             input_liabilities=round(inputs.liabilities, 2),   
             input_equity=round(inputs.equity, 2),
             input_revenue=round(inputs.revenue, 2),
-            input_gross_profit=round(gross_income, 2),       
+            input_gross_profit=round(gross_income, 2),        
             input_net_income=round(net_income, 2),
             input_taxes=round(inputs.taxes, 2),
 
-            # Datos crudos absolutos para auditoría y transparencia (sin procesar, con signo original)
             raw_net_profit=round(inputs.net_profit, 2),
             raw_net_loss=round(inputs.net_loss, 2),
             raw_ebit_profit=round(inputs.ebit_profit, 2),

--- a/Fluxo_IA_visual/services/prequalification/data_collector.py
+++ b/Fluxo_IA_visual/services/prequalification/data_collector.py
@@ -146,10 +146,11 @@ class DataCollectorService:
                         
                         # Disparamos todas las sumas al mismo tiempo
                         if tasks:
-                            resultados_montos = await asyncio.gather(*tasks)
+                            resultados_facturas = await asyncio.gather(*tasks)
                             # Inyectamos el resultado directamente en el diccionario crudo original
-                            for meta_item, monto_total in zip(task_meta, resultados_montos):
+                            for meta_item, (monto_total, ultima_fecha) in zip(task_meta, resultados_facturas):
                                 meta_item["monto_acumulado"] = monto_total
+                                meta_item["ultima_factura_fecha"] = ultima_fecha
 
             else:
                 logger.warning(f"[{rfc}] Omitiendo OLA 2: No se encontró Entity ID.")

--- a/Fluxo_IA_visual/services/prequalification/processors/financial_processor.py
+++ b/Fluxo_IA_visual/services/prequalification/processors/financial_processor.py
@@ -30,7 +30,7 @@ class FinancialProcessor:
         stats_windows = self._calculate_advanced_stats(raw_cashflow, raw_sales, raw_expenditures)
         
         # 2. Árbol Financiero y Ratios
-        financial_ratios = self._process_financial_statements(financial_tree)
+        financial_ratios = self._process_financial_statements(financial_tree, raw_cashflow)
         
         # 3. Preparación Histórica para Forecaster y Excel (Raw Data)
         raw_history_list, simple_sales, simple_exp, simple_in, simple_out = self._prepare_time_series(
@@ -107,16 +107,15 @@ class FinancialProcessor:
             
         return raw_history_list, simple_sales, simple_exp, simple_in, simple_out
 
-    def _process_financial_statements(self, tree: Dict[str, Any]) -> List[PrequalificationResponse.FinancialRatioYear]:
-        """Extrae el árbol usando métodos del cliente y lo pasa a la calculadora."""
+    def _process_financial_statements(self, tree: Dict[str, Any], raw_cashflow: Dict[str, Any]) -> List[PrequalificationResponse.FinancialRatioYear]:
         bs_tree = tree.get("balance_sheet", {})
         is_tree = tree.get("income_statement", {})
 
+        # --- 1. EXTRACCIÓN DEL ÁRBOL ---
         assets = SyntageClient.parse_values_from_tree(bs_tree, ["Activo", "Total Activo"])
         liabilities = SyntageClient.parse_values_from_tree(bs_tree, ["Pasivo", "Total Pasivo"])
-        equity = SyntageClient.parse_values_from_tree(bs_tree, ["capital contable", "total capital", "capital"])
+        equity = SyntageClient.parse_values_from_tree(bs_tree, ["Capital contable", "Total capital", "Capital"])
         
-        # --- EXTRACCIÓN DEL DESGLOSE ---
         assets_st = SyntageClient.parse_values_from_tree(bs_tree, ["Activo a corto plazo"])
         assets_lt = SyntageClient.parse_values_from_tree(bs_tree, ["Activo a largo plazo"])
         liabilities_st = SyntageClient.parse_values_from_tree(bs_tree, ["Pasivo a corto plazo"])
@@ -133,6 +132,16 @@ class FinancialProcessor:
         ebit_loss = SyntageClient.parse_values_from_tree(is_tree, ["Pérdida de operación"])
         ebt_profit = SyntageClient.parse_values_from_tree(is_tree, ["Utilidad antes de Impuestos a la utilidad", "Utilidad antes de impuestos", "EBT"])
         ebt_loss = SyntageClient.parse_values_from_tree(is_tree, ["Pérdida antes de Impuestos a la utilidad", "Pérdida antes de impuestos"])
+
+        # CUENTAS CONTABLES PARA RATIOS
+        cash_eq = SyntageClient.parse_values_from_tree(bs_tree, ["Efectivo y equivalentes de efectivo"])
+        inventory = SyntageClient.parse_values_from_tree(bs_tree, ["Inventarios"])
+        accounts_rec = SyntageClient.parse_values_from_tree(bs_tree, ["Cuentas y documentos por cobrar", "Clientes"])
+        accounts_pay = SyntageClient.parse_values_from_tree(bs_tree, ["Cuentas y documentos por pagar", "Proveedores"])
+        fixed_assets = SyntageClient.parse_values_from_tree(bs_tree, ["Propiedades, plantas y equipo", "Propiedades, planta y equipo"])
+        retained_earnings = SyntageClient.parse_values_from_tree(bs_tree, ["Utilidades acumuladas"])
+        cogs = SyntageClient.parse_values_from_tree(is_tree, ["Costo de ventas"])
+        interest_exp = SyntageClient.parse_values_from_tree(is_tree, ["Gastos por intereses", "Gastos Financieros"])
 
         valid_years = set()
         candidates = set(assets.keys()) | set(revenue.keys()) | set(ebit_profit.keys())
@@ -151,8 +160,15 @@ class FinancialProcessor:
             raw_ebt_p = ebt_profit.get(year, 0.0)
             raw_ebt_l = ebt_loss.get(year, 0.0)
             ebt = raw_ebt_p - raw_ebt_l
-            
             calculated_taxes = round(ebt - net_income, 2)
+
+            # --- CÁLCULO DEL FLUJO OPERATIVO DE CAJA ANUAL ---
+            ocf_year = 0.0
+            for d_key, d_val in raw_cashflow.items():
+                if str(d_key).startswith(year): # Suma todos los meses que empiecen con "2023", etc.
+                    inf = float(d_val.get("in", {}).get("amount", 0.0))
+                    outf = float(d_val.get("out", {}).get("amount", 0.0))
+                    ocf_year += (inf - outf)
 
             year_input = PrequalificationResponse.FinancialYearInput(
                 year=year,
@@ -168,11 +184,24 @@ class FinancialProcessor:
                 ebit_profit=ebit_profit.get(year, 0.0),
                 ebit_loss=ebit_loss.get(year, 0.0),
                 ebt_profit=raw_ebt_p,
-                ebt_loss=raw_ebt_l
+                ebt_loss=raw_ebt_l,
+                
+                # Cuentas circulantes y para ratios
+                current_assets=assets_st.get(year, 0.0),
+                current_liabilities=liabilities_st.get(year, 0.0),
+                cash_and_equivalents=cash_eq.get(year, 0.0),
+                inventory=inventory.get(year, 0.0),
+                accounts_receivable=accounts_rec.get(year, 0.0),
+                accounts_payable=accounts_pay.get(year, 0.0),
+                fixed_assets=fixed_assets.get(year, 0.0),
+                retained_earnings=retained_earnings.get(year, 0.0),
+                cogs=cogs.get(year, 0.0),
+                interest_expense=interest_exp.get(year, 0.0),
+                operating_cash_flow=ocf_year
             )
             ratios = self.calculator.calculate_ratios_for_year(year_input)
             
-            # --- INYECCIÓN DEL DESGLOSE ---
+            # --- INYECCIÓN DE DATOS EXTRA AL RESULTADO FINAL ---
             ratios.input_assets_short_term = assets_st.get(year, 0.0)
             ratios.input_assets_long_term = assets_lt.get(year, 0.0)
             ratios.input_liabilities_short_term = liabilities_st.get(year, 0.0)
@@ -227,12 +256,15 @@ class FinancialProcessor:
                 mean_val = statistics.mean(vals_curr) if vals_curr else 0.0
                 median_val = statistics.median(vals_curr) if vals_curr else 0.0
                 
-                sum_curr = sum(vals_curr)
-                sum_prev = sum(vals_prev) if prev_window else 0.0
+                sum_curr = sum(vals_curr) # Suma total del periodo actual
+                sum_prev = sum(vals_prev) if prev_window else 0.0 # Suma total del periodo anterior equivalente
                 
+                # Cálculo de crecimiento porcentual del periodo actual vs anterior
+                # Se compara la suma total del periodo actual con la suma total del periodo anterior equivalente (ej: últimos 6 meses vs 6 meses anteriores)
                 period_growth = None 
                 if prev_window:
                     if sum_prev != 0:
+                        # (Actual - Anterior) / Anterior
                         period_growth = (sum_curr - sum_prev) / abs(sum_prev)
                     else:
                         period_growth = 1.0 if sum_curr > 0 else 0.0

--- a/Fluxo_IA_visual/services/prequalification/processors/network_processor.py
+++ b/Fluxo_IA_visual/services/prequalification/processors/network_processor.py
@@ -73,7 +73,11 @@ class NetworkProcessor:
             
             # 2. Excluir el mes actual SOLO para la matemática de la pendiente
             current_month = datetime.now().strftime("%Y-%m")
-            transactions_clean = [t for t in transactions_sorted if t.get("date") != current_month]
+            # Usamos startswith para interceptar "2026-04-01" o "2026-04" sin importar el día
+            transactions_clean = [
+                t for t in transactions_sorted 
+                if not str(t.get("date", "")).startswith(current_month)
+            ]
             
             vals = [float(t.get("total", 0.0)) for t in transactions_clean]
             

--- a/Fluxo_IA_visual/services/prequalification/processors/risk_processor.py
+++ b/Fluxo_IA_visual/services/prequalification/processors/risk_processor.py
@@ -2,6 +2,7 @@
 from typing import Dict, Any, List
 import logging
 import json
+from datetime import datetime
 from ....models.responses_precalificacion import PrequalificationResponse
 from ...ia_extractor import analizar_gpt_fluxo
 from ....utils.helpers_texto_precalificación import prompt_32d
@@ -58,6 +59,7 @@ class RiskProcessor:
                 # Extraemos las facturas y el monto que la OLA 3 nos inyectó
                 count = int(item.get("invoices", 0))
                 monto = float(item.get("monto_acumulado", 0.0))
+                fecha_factura = item.get("ultima_factura_fecha", "N/A") 
                 
                 # Sumamos a la cubeta correspondiente
                 if category == "issued":
@@ -66,6 +68,11 @@ class RiskProcessor:
                 else:
                     dict_counterparties[rfc_val]["received_count"] += count
                     dict_counterparties[rfc_val]["received_amount"] += monto
+                    
+                # Guardar la fecha (si no existía una o si la nueva es mayor cronológicamente)
+                fecha_actual = dict_counterparties[rfc_val].get("last_invoice_date", "N/A")
+                if fecha_actual == "N/A" or (fecha_factura != "N/A" and fecha_factura > fecha_actual):
+                    dict_counterparties[rfc_val]["last_invoice_date"] = fecha_factura
 
         # Convertimos el diccionario agrupado al modelo Pydantic
         blacklisted_counterparties = [
@@ -113,10 +120,32 @@ class RiskProcessor:
             ]
         )
 
+        # CÁLCULO DE ANTIGÜEDAD DE ACTIVIDADES
+        processed_activities = []
+        ahora = datetime.now()
+        
+        for act in activities:
+            start_date_str = act.get("start_date")
+            antiguedad = 0
+            
+            if start_date_str:
+                try:
+                    # Parsear la fecha (cortamos a 10 chars por si trae horas YYYY-MM-DD)
+                    dt_start = datetime.strptime(str(start_date_str)[:10], "%Y-%m-%d")
+                    # Calculamos los años exactos (restando 1 si aún no pasa su mes/día de aniversario este año)
+                    antiguedad = ahora.year - dt_start.year - ((ahora.month, ahora.day) < (dt_start.month, dt_start.day))
+                except Exception as e:
+                    logger.warning(f"Error parseando fecha de actividad '{start_date_str}': {e}")
+                    
+            processed_activities.append(PrequalificationResponse.EconomicActivity(
+                name=act.get("name", "N/A"),
+                percentage=float(act.get("percentage", 0.0)),
+                start_date=start_date_str,
+                seniority_years=antiguedad
+            ))
+
         return {
-            "economic_activities": [
-                PrequalificationResponse.EconomicActivity(**act) for act in activities
-            ],
+            "economic_activities": processed_activities,
             "risk_indicators": raw_data.get("risks", []),
             "employee_metrics": self._process_employees(raw_employees),
             "blacklisted_counterparties": blacklisted_counterparties,

--- a/Fluxo_IA_visual/services/report_generator/sheets/s01_executive_summary.py
+++ b/Fluxo_IA_visual/services/report_generator/sheets/s01_executive_summary.py
@@ -75,11 +75,11 @@ def build(ws, data: dict):
         ws.append([])
         ws.append(["CONTRAPARTES EN LISTA NEGRA (69-B SAT)"])
         fila_bl = ws.max_row
-        ws.merge_cells(f'A{fila_bl}:E{fila_bl}')
-        aplicar_estilo_header(ws, fila_bl, 1, 5)
+        ws.merge_cells(f'A{fila_bl}:F{fila_bl}')
+        aplicar_estilo_header(ws, fila_bl, 1, 6)
         
-        ws.append(["RFC", "Razón Social", "Estatus SAT", "Facturas (Emit. / Recib.)", "Monto Total Involucrado"])
-        aplicar_estilo_header(ws, ws.max_row, 1, 5)
+        ws.append(["RFC", "Razón Social", "Estatus SAT", "Última Factura", "Facturas (Emit. / Recib.)", "Monto Total Involucrado"])
+        aplicar_estilo_header(ws, ws.max_row, 1, 6)
         
         # Traductor de estatus para que el analista lo lea en español
         status_map = {
@@ -102,30 +102,41 @@ def build(ws, data: dict):
             # Sumamos lo que le compramos y lo que le vendimos para ver el riesgo total
             monto_total = float(b.get("issued_amount", 0.0)) + float(b.get("received_amount", 0.0))
             
-            ws.append([b_rfc, b_name, b_status_es, apariciones, monto_total])
+            ultima_fecha = b.get("last_invoice_date", "N/A")
             
-            # Formato de Moneda
-            ws.cell(row=ws.max_row, column=5).number_format = CURRENCY_FORMAT
+            # Intentar acceder como objeto primero, luego como dict
+            try: ultima_fecha = b.last_invoice_date
+            except: ultima_fecha = b.get("last_invoice_date", "N/A")
+
+            ws.append([b_rfc, b_name, b_status_es, ultima_fecha, apariciones, monto_total])
+            
+            # Formato de Moneda (ahora en la columna 6)
+            ws.cell(row=ws.max_row, column=6).number_format = CURRENCY_FORMAT
             
             # Alerta visual en rojo
             if b_status_raw in ["definitive", "presumed"]:
                 ws.cell(row=ws.max_row, column=3).fill = ALERT_FILL
                 
-        # Aseguramos que la columna nueva tenga buen ancho
-        ws.column_dimensions['E'].width = 25
+        # Aseguramos anchos
+        ws.column_dimensions['B'].width = 30
+        ws.column_dimensions['D'].width = 15 # Última factura
+        ws.column_dimensions['F'].width = 25 # Monto total
 
     # 4. ACTIVIDADES ECONÓMICAS
     ws.append([])
     ws.append(["ACTIVIDADES ECONÓMICAS"])
     ws.merge_cells(f'A{ws.max_row}:D{ws.max_row}')
     aplicar_estilo_header(ws, ws.max_row, 1, 4)
-    ws.append(["Actividad", "Porcentaje", "Fecha Inicio", ""])
+    
+    ws.append(["Actividad", "Porcentaje", "Fecha Inicio", "Antigüedad (Años)"])
+    aplicar_estilo_subheader(ws, ws.max_row, 1, 4) # Le ponemos estilo al subheader
     
     acts = data.get("economic_activities", [])
     
     # Regex para detectar caracteres de control ilegales en XML/Excel
     ILLEGAL_CHARACTERS_RE = re.compile(r'[\000-\010]|[\013-\014]|[\016-\037]')
 
+    start_row = ws.max_row + 1    
     for act in acts:
         pct_str = f"{act.get('percentage', 0)}%"
         
@@ -138,36 +149,29 @@ def build(ws, data: dict):
         # 3. Quitamos saltos de línea y espacios múltiples para que se vea limpio
         clean_name = " ".join(clean_name.split())
         
-        ws.append([clean_name, pct_str, act.get("start_date"), ""])# 4. ACTIVIDADES ECONÓMICAS
+        # 4. Extraemos seniority_years y lo ponemos en la 4ta columna
+        antiguedad = act.get("seniority_years", 0)
+        
+        ws.append([clean_name, pct_str, act.get("start_date"), antiguedad])
+    
+    end_row = ws.max_row
+    
     ws.append([])
-    ws.append(["ACTIVIDADES ECONÓMICAS"])
-    ws.merge_cells(f'A{ws.max_row}:D{ws.max_row}')
-    aplicar_estilo_header(ws, ws.max_row, 1, 4)
-    ws.append(["Actividad", "Porcentaje", "Fecha Inicio", ""])
-    
-    acts = data.get("economic_activities", [])
-    
-    # Regex para detectar caracteres de control ilegales en XML/Excel
-    ILLEGAL_CHARACTERS_RE = re.compile(r'[\000-\010]|[\013-\014]|[\016-\037]')
 
-    for act in acts:
-        pct_str = f"{act.get('percentage', 0)}%"
-        
-        # 1. Obtenemos el texto crudo
-        raw_name = str(act.get("name", "N/A"))
-        
-        # 2. Eliminamos caracteres ilegales
-        clean_name = ILLEGAL_CHARACTERS_RE.sub("", raw_name)
-        
-        # 3. Quitamos saltos de línea y espacios múltiples para que se vea limpio
-        clean_name = " ".join(clean_name.split())
-        
-        ws.append([clean_name, pct_str, act.get("start_date"), ""])
-
-    ws.column_dimensions['A'].width = 30
-    ws.column_dimensions['B'].width = 20
-    ws.column_dimensions['C'].width = 20
-    ws.column_dimensions['D'].width = 20
+    ws.column_dimensions['A'].width = 40
+    ws.column_dimensions['B'].width = 15
+    ws.column_dimensions['C'].width = 15
+    ws.column_dimensions['D'].width = 20 # Espacio para "Antigüedad (Años)"
+    
+    # Centramos los datos de Porcentaje, Fecha y Antigüedad para que se vea más profesional
+    for row in ws.iter_rows(
+        min_row=start_row,
+        max_row=end_row,
+        min_col=2,
+        max_col=4
+    ):
+        for cell in row:
+            cell.alignment = Alignment(horizontal='center')
 
     # 4.5 EVOLUCIÓN DE EMPLEADOS (NUEVO RECUADRO)
     ws.append([])
@@ -316,3 +320,32 @@ def build(ws, data: dict):
         print_fin_row("Utilidad (Pérdida) antes de Impuestos", "ebt")
         print_fin_row("Impuestos a la Utilidad", "input_taxes")
         print_fin_row("Utilidad (Pérdida) Neta", "input_net_income", is_bold=True)
+    
+    # 7. RESUMEN DE INSTITUCIONES FINANCIERAS
+
+    institutions = data.get("financial_institutions", [])
+    if institutions:
+        ws.append([])
+        ws.append(["RESUMEN DE INSTITUCIONES FINANCIERAS (TOP 10)"])
+        ws.merge_cells(f'A{ws.max_row}:B{ws.max_row}')
+        aplicar_estilo_header(ws, ws.max_row, 1, 2)
+        
+        ws.append(["Institución Financiera", "Última Transacción"])
+        aplicar_estilo_subheader(ws, ws.max_row, 1, 2)
+        
+        # Mostramos solo las 10 principales para no saturar la carátula
+        for inst in institutions[:10]:
+            try:
+                # Preferimos el nombre comercial si existe y no es "N/A"
+                nombre = inst.trade_name if inst.trade_name and inst.trade_name != "N/A" else inst.legal_name
+                ultima_fecha = inst.last_transaction_date
+            except AttributeError:
+                # Fallback por si llega como diccionario
+                t_name = inst.get("trade_name")
+                nombre = t_name if t_name and t_name != "N/A" else inst.get("legal_name")
+                ultima_fecha = inst.get("last_transaction_date")
+                
+            ws.append([nombre, ultima_fecha, "", ""])
+            
+            # Centramos la fecha para que se vea ordenado
+            ws.cell(row=ws.max_row, column=2).alignment = Alignment(horizontal='center')

--- a/Fluxo_IA_visual/services/report_generator/sheets/s05_financial_stmts.py
+++ b/Fluxo_IA_visual/services/report_generator/sheets/s05_financial_stmts.py
@@ -22,7 +22,7 @@ def build(ws, data: dict):
     conceptos_financieros = [
         ("--- DATOS CONSOLIDADOS ---", None),
         ("Activos Totales", "input_assets"),
-        ("Pasivo Total", "input_liabilities"),           
+        ("Pasivo Total", "input_liabilities"),            
         ("Capital Contable (Equity)", "input_equity"),
         ("Ingresos Netos (Revenue)", "input_revenue"),
         ("Utilidad (Pérdida) Bruta", "input_gross_profit"), 
@@ -33,19 +33,55 @@ def build(ws, data: dict):
         ("NOPAT", "nopat"),
         
         ("", None), 
+        ("--- LIQUIDEZ ---", None),
+        ("Razón Actual (Circulante)", "current_ratio"),
+        ("Prueba del Ácido", "quick_ratio"),
+        ("Liquidez Inmediata", "cash_ratio"),
+
+        ("", None), 
+        ("--- RENDIMIENTO SOBRE LA INVERSIÓN (ROI) ---", None),
+        ("Rendimiento del Capital (ROE)", "roe"),
+        ("Rendimiento de los Activos (ROA)", "roa"),
+        ("Rendimiento Activos (Estrategia Fiscal)", "roa_tax_strategy"),
+        ("Margen de Utilidad Neta (%)", "net_profit_margin_percent"),
+
+        ("", None), 
+        ("--- ESTRUCTURA DE CAPITAL Y SOLVENCIA ---", None),
+        ("Apalancamiento", "leverage"),
+        ("Endeudamiento", "debt_ratio"),
+        ("Cobertura de Intereses", "interest_coverage"),
+
+        ("", None), 
+        ("--- FLUJO DE FONDOS ---", None),
+        ("Flujo Operativo de Caja", "operating_cash_flow"),
+        ("Cobertura de Flujo", "cash_flow_coverage"),
+        ("Capital de Trabajo", "working_capital"),
+
+        ("", None), 
+        ("--- DESEMPEÑO DE LA OPERACIÓN ---", None),
+        ("Rotación de Inventario (Días - DIO)", "dio"),
+        ("Rotación de CxC (Días - DSO)", "dso"),
+        ("Rotación de CxP (Días - DPO)", "dpo"),
+        ("Rotación de Activo Fijo", "fixed_asset_turnover"),
+        ("Rotación de Activo Total", "total_asset_turnover"),
+        ("Indicador de Altman (Z-Score)", "altman_z_score"),
+
+        ("", None), 
         ("--- DATOS CRUDOS EXTRAÍDOS ---", None),
         ("Utilidad Neta (Crudo)", "raw_net_profit"),
         ("Pérdida Neta (Crudo)", "raw_net_loss"),
         ("Utilidad Operativa (Crudo)", "raw_ebit_profit"),
         ("Pérdida Operativa (Crudo)", "raw_ebit_loss"),
         ("Utilidad antes de Imp. (Crudo)", "raw_ebt_profit"),
-        ("Pérdida antes de Imp. (Crudo)", "raw_ebt_loss"),
-        
-        ("", None), 
-        ("--- RAZONES FINANCIERAS ---", None),
-        ("ROA", "roa"),
-        ("ROE", "roe"),
-        ("Margen Neto (%)", "net_profit_margin_percent")
+        ("Pérdida antes de Imp. (Crudo)", "raw_ebt_loss")
+    ]
+    
+    # Lista de llaves que son índices, múltiplos o días (formato decimal simple)
+    llaves_decimales = [
+        "roa", "roe", "roa_tax_strategy", "current_ratio", "quick_ratio", 
+        "cash_ratio", "leverage", "debt_ratio", "interest_coverage", 
+        "cash_flow_coverage", "dio", "dso", "dpo", "fixed_asset_turnover", 
+        "total_asset_turnover", "altman_z_score"
     ]
     
     for label, key in conceptos_financieros:
@@ -64,11 +100,18 @@ def build(ws, data: dict):
         curr_row = ws.max_row
         for col_idx in range(2, len(years) + 2):
             cell = ws.cell(row=curr_row, column=col_idx)
-            if key in ["roa", "roe", "net_profit_margin_percent"]:
+            
+            # --- LÓGICA DE FORMATOS INTELIGENTE ---
+            if key == "net_profit_margin_percent":
+                # Porcentajes puros
                 cell.number_format = PERCENT_FORMAT
-                if key != "net_profit_margin_percent" and cell.value: 
-                    cell.value = cell.value / 100 
+                if cell.value:
+                    cell.value = cell.value / 100
+            elif key in llaves_decimales:
+                # Índices, días y veces (sin símbolo de pesos)
+                cell.number_format = '0.00'
             else:
+                # Flujo operativo, Capital de trabajo y Cuentas base son Dinero
                 cell.number_format = CURRENCY_FORMAT
 
     ws.column_dimensions['A'].width = 40

--- a/Fluxo_IA_visual/services/syntage_client.py
+++ b/Fluxo_IA_visual/services/syntage_client.py
@@ -1197,7 +1197,7 @@ class SyntageClient:
             logger.error(f"Error fetching RUG records: {e}")
         return []
     
-    async def get_invoice_totals_by_rfc(self, client: httpx.AsyncClient, entity_id: str, rfc_contraparte: str, as_receiver: bool) -> float:
+    async def get_invoice_totals_by_rfc(self, client: httpx.AsyncClient, entity_id: str, rfc_contraparte: str, as_receiver: bool) -> tuple[float, str]:
         """
         as_receiver=True -> Facturas donde la contraparte es RECEPTOR (Facturas Emitidas por nosotros).
         as_receiver=False -> Facturas donde la contraparte es EMISOR (Facturas Recibidas por nosotros).
@@ -1209,25 +1209,36 @@ class SyntageClient:
             # Usamos property filtering para que la API no nos mande los XML completos, solo el total
             params = {
                 param_key: rfc_contraparte,
-                "properties[]": "total",
-                "itemsPerPage": 500  # Un número alto para traer todo rápido
+                "properties[]": ["total", "issuedAt"],
+                "order[issuedAt]": "desc",
+                "itemsPerPage": 500  
             }
             url = f"{self.base_url}/entities/{entity_id}/invoices"
             resp = await client.get(url, params=params, headers=self.headers)
             
             if resp.status_code == 200:
+                logger.debug(f"Debug de respuesta: {resp.text[:800]}")  # Logueamos los primeros 800 caracteres para ver qué estructura nos dio Syntage
                 data = resp.json()
                 items = data if isinstance(data, list) else data.get("hydra:member", [])
                 
-                # Sumamos el campo 'total' de todas las facturas encontradas
-                return sum(float(i.get("total", 0.0)) for i in items if isinstance(i, dict))
+                if not items:
+                    return 0.0, "N/A"
+
+                # Como ordenamos por 'issuedAt' desc, el primer elemento es la factura más reciente
+                monto_total = sum(float(i.get("total", 0.0)) for i in items if isinstance(i, dict))
+                
+                # Extraer la fecha (solo los primeros 10 caracteres YYYY-MM-DD)
+                ultima_fecha_cruda = str(items[0].get("issuedAt", "N/A"))
+                ultima_fecha = ultima_fecha_cruda[:10] if ultima_fecha_cruda != "N/A" else "N/A"
+                
+                return monto_total, ultima_fecha
             else:
                 logger.warning(f"Error HTTP {resp.status_code} al obtener facturas de {rfc_contraparte}.")
                 
         except Exception as e:
-            logger.error(f"Error sumando facturas para 69-B ({rfc_contraparte}): {e}")
+            logger.error(f"Error procesando facturas para 69-B ({rfc_contraparte}): {e}")
             
-        return 0.0
+        return 0.0, "N/A"
 
     async def download_file_content(self, client: httpx.AsyncClient, file_id: str) -> bytes:
         """


### PR DESCRIPTION
- Calculo de antiguedad en anos para Actividades Economicas (procesador y caratula).

- Extraccion de cuentas y calculo de 16 nuevas razones financieras (Liquidez, Solvencia, ROI, Altman Z, etc.).

- Fix: Formatos de ROA, ROE y Margen Neto en hoja de Estados Financieros.

- Fix: Slope de concentracion comercial ahora incluye el mes actual para cuadrar con el calculo manual.

- Agregado cuadro de Resumen Top 5 de Instituciones Financieras a la caratula.

- Obtencion de fecha de ultima factura (issuedAt) para contrapartes bloqueadas (69-B) e inyeccion en Excel.