### PR TITLE
fix: resolver AttributeError en logs de ErrorRespuesta y anadir retro…

### DIFF
--- a/Fluxo_IA_visual/models/responses_analisisTPV.py
+++ b/Fluxo_IA_visual/models/responses_analisisTPV.py
@@ -7,9 +7,12 @@ class AnalisisTPV:
     """Namespace para todos los modelos relacionados con el analisis de cuenta TPV."""
     class ErrorRespuesta(BaseModel):
         """Error específico para el procesamiento de TPV."""
-        nombre_documento: str
-        estatus_documento: str = "fallido"
-        detalle_error: str
+        nombre_documento: str = Field(default="Desconocido")
+        estatus_documento: str = Field(default="fallido")
+        detalle_error: str = Field(alias="error")
+
+        class Config:
+            populate_by_name = True # Permite que Pydantic acepte tanto 'error' como 'detalle_error' al construirlo
 
     class Transaccion(BaseModel):
         """Representa una única transaccion encontrada dentro del documento [3 partes]."""

--- a/Fluxo_IA_visual/services/processing_service.py
+++ b/Fluxo_IA_visual/services/processing_service.py
@@ -692,7 +692,7 @@ class ProcessingService:
             return
 
         if isinstance(resultado_doc.DetalleTransacciones, AnalisisTPV.ErrorRespuesta): 
-            logger.warning(f"[TRACKING OCR - 4] {nombre_doc} descartado por ErrorRespuesta: {resultado_doc.DetalleTransacciones.error}")
+            logger.warning(f"[TRACKING OCR - 4] {nombre_doc} descartado por ErrorRespuesta: {resultado_doc.DetalleTransacciones.detalle_error}")
             return
         # ----------------------
 


### PR DESCRIPTION
…compatibilidad

- Se soluciono el AttributeError en _clasificar_documento_async (processing_service.py) actualizando la referencia del atributo de .error a .detalle_error en el logger.

- Se configuro retrocompatibilidad en el modelo ErrorRespuesta (responses_analisisTPV.py) utilizando alias='error' y populate_by_name=True de Pydantic.

- Se agregaron valores por defecto en el modelo de error (nombre_documento='Desconocido') para asegurar que el codigo legacy no rompa el orquestador general al instanciar errores.